### PR TITLE
Add a timeout to ruby-setup in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
+      timeout-minutes: 30
     - name: Prepare tests
       run: bin/setup
     - name: Run tests


### PR DESCRIPTION
Prevent ruby-setup from hanging for hours