### PR TITLE
Workaround attribute default triggering changes

### DIFF
--- a/app/models/manageiq/providers/awx/automation_manager.rb
+++ b/app/models/manageiq/providers/awx/automation_manager.rb
@@ -25,7 +25,7 @@ class ManageIQ::Providers::Awx::AutomationManager < ManageIQ::Providers::Externa
   belongs_to :provider, :autosave => true, :dependent => :destroy
   before_validation :update_provider_zone
 
-  after_save :change_maintenance_for_provider, :if => proc { |ems| ems.saved_change_to_enabled? }
+  after_save :change_maintenance_for_provider, :if => proc { |ems| ems.saved_change_to_enabled? && !ems.enabled_before_last_save.nil? }
 
   supports :catalog
   supports :create


### PR DESCRIPTION
This was caused by the change to use attribute default in enabled on ExtManagementSystem from this commit:
https://github.com/ManageIQ/manageiq/commit/5b5e9273efafc8954db11cc160306cea0d13681c

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
