### PR TITLE
Fix Job#job_template class_name resolving to Awx namespace

### DIFF
--- a/app/models/manageiq/providers/awx/automation_manager/job.rb
+++ b/app/models/manageiq/providers/awx/automation_manager/job.rb
@@ -2,7 +2,7 @@ class ManageIQ::Providers::Awx::AutomationManager::Job <
   ManageIQ::Providers::ExternalAutomationManager::OrchestrationStack
 
   belongs_to :ext_management_system, :foreign_key => :ems_id, :class_name => "ManageIQ::Providers::AutomationManager"
-  belongs_to :job_template, :foreign_key => :configuration_script_id, :class_name => "ConfigurationScript"
+  belongs_to :job_template, :foreign_key => :configuration_script_id, :class_name => "::ConfigurationScript"
   belongs_to :playbook, :foreign_key => :configuration_script_base_id
 
   virtual_has_many :job_plays


### PR DESCRIPTION
The `ManageIQ::Providers::Awx::AutomationManager::Job#job_template`  association had a `:class_name => "ConfigurationScript"` which was resolving to `ManageIQ::Providers::Awx::AutomationManager::ConfigurationScript`

This was causing issues with the AnsibleTower subclass with `ActsAsStiLeafClass` because `ManageIQ::Providers::AnsibleTower::AutomationManager::ConfigurationScript` is not an STI subclass of `ManageIQ::Providers::Awx::AutomationManager::ConfigurationScript` causing `child_job.job_template` to be `nil`

Required for
* https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/301
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
