### PR TITLE
Delay load the ansible tower client

### DIFF
--- a/app/models/manageiq/providers/awx/automation_manager/job.rb
+++ b/app/models/manageiq/providers/awx/automation_manager/job.rb
@@ -1,4 +1,3 @@
-require 'ansible_tower_client'
 class ManageIQ::Providers::Awx::AutomationManager::Job <
   ManageIQ::Providers::ExternalAutomationManager::OrchestrationStack
 
@@ -72,6 +71,7 @@ class ManageIQ::Providers::Awx::AutomationManager::Job <
   end
 
   def refresh_ems
+    require 'ansible_tower_client'
     ext_management_system.with_provider_connection do |connection|
       update_with_provider_object(connection.api.jobs.find(ems_ref))
     end
@@ -144,6 +144,7 @@ class ManageIQ::Providers::Awx::AutomationManager::Job <
   private :update_plays
 
   def raw_status
+    require 'ansible_tower_client'
     ext_management_system.with_provider_connection do |connection|
       raw_job = connection.api.jobs.find(ems_ref)
       self.class.status_class.new(raw_job.status, nil)
@@ -157,6 +158,7 @@ class ManageIQ::Providers::Awx::AutomationManager::Job <
   end
 
   def raw_stdout(format = 'txt')
+    require 'ansible_tower_client'
     ext_management_system.with_provider_connection do |connection|
       connection.api.jobs.find(ems_ref).stdout(format)
     end
@@ -169,6 +171,7 @@ class ManageIQ::Providers::Awx::AutomationManager::Job <
   end
 
   def raw_artifacts
+    require 'ansible_tower_client'
     ext_management_system.with_provider_connection do |connection|
       connection.api.jobs.find(ems_ref).artifacts
     end

--- a/app/models/manageiq/providers/awx/automation_manager/tower_api.rb
+++ b/app/models/manageiq/providers/awx/automation_manager/tower_api.rb
@@ -9,6 +9,7 @@ module ManageIQ::Providers::Awx::AutomationManager::TowerApi
     end
 
     def create_in_provider(manager_id, params)
+      require 'ansible_tower_client'
       manager = ExtManagementSystem.find(manager_id)
       tower_object = raw_create_in_provider(manager, params)
       refresh_in_provider_notify(manager_id, params, tower_object)
@@ -75,6 +76,7 @@ module ManageIQ::Providers::Awx::AutomationManager::TowerApi
   end
 
   def update_in_provider(params)
+    require 'ansible_tower_client'
     self.class.process_secrets(params, true) if self.class.respond_to?(:process_secrets)
     params.delete(:task_id) # in case this is being called through update_in_provider_queue which will stick in a :task_id
     params.delete(:miq_task_id) # miq_queue.activate_miq_task will stick in a :miq_task_id
@@ -104,6 +106,7 @@ module ManageIQ::Providers::Awx::AutomationManager::TowerApi
   end
 
   def delete_in_provider
+    require 'ansible_tower_client'
     raw_delete_in_provider
     self.class.send('refresh', manager)
   rescue AnsibleTowerClient::ClientError => error

--- a/app/models/manageiq/providers/awx/automation_manager/workflow_job.rb
+++ b/app/models/manageiq/providers/awx/automation_manager/workflow_job.rb
@@ -41,6 +41,7 @@ class ManageIQ::Providers::Awx::AutomationManager::WorkflowJob <
   end
 
   def raw_status
+    require 'ansible_tower_client'
     ext_management_system.with_provider_connection do |connection|
       raw_job = connection.api.workflow_jobs.find(ems_ref)
       self.class.status_class.new(raw_job.status, nil)
@@ -73,6 +74,7 @@ class ManageIQ::Providers::Awx::AutomationManager::WorkflowJob <
   private_class_method :reconcile_extra_vars_keys
 
   def refresh_ems
+    require 'ansible_tower_client'
     ext_management_system.with_provider_connection do |connection|
       update_with_provider_object(connection.api.workflow_jobs.find(ems_ref))
     end

--- a/app/models/manageiq/providers/awx/inventory/collector/target_collection.rb
+++ b/app/models/manageiq/providers/awx/inventory/collector/target_collection.rb
@@ -75,6 +75,7 @@ class ManageIQ::Providers::Awx::Inventory::Collector::TargetCollection < ManageI
   # @param inventory_collection_name [Symbol] IC name (as identified in persister's definitions)
   # @param endpoint - endpoint for AnsibleTowerClient api call
   def find_records(inventory_collection_name, endpoint)
+    require 'ansible_tower_client'
     refs = references(inventory_collection_name)
     return [] if refs.blank?
 


### PR DESCRIPTION
We shouldn't load the client when loading the domain classes.  Instead, we should load it when needed.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
