### PR TITLE
Use common Ansible template parent class in runner

### DIFF
--- a/app/models/manageiq/providers/awx/automation_manager/template_runner.rb
+++ b/app/models/manageiq/providers/awx/automation_manager/template_runner.rb
@@ -73,7 +73,7 @@ class ManageIQ::Providers::Awx::AutomationManager::TemplateRunner < ::Job
   end
 
   def job_template
-    @template ||= ManageIQ::Providers::ExternalAutomationManager::ConfigurationScript.find(options[:ansible_template_id])
+    @template ||= ManageIQ::Providers::AutomationManager::ConfigurationScript.find(options[:ansible_template_id])
   end
 
   def wait_on_ansible_job


### PR DESCRIPTION
Since Ansible workflow templates are not under the `ExternalAutomationManager` parent class this would cause the following error when running a workflow template
```
/Users/nasarkhan/.rvm/gems/ruby-3.0.1/gems/activerecord-7.0.8.4/lib/active_record/core.rb:284:in `find': Couldn't find ManageIQ::Providers::ExternalAutomationManager::ConfigurationScript with 'id'=30 (ActiveRecord::RecordNotFound)
	from /Users/nasarkhan/Documents/manageiq/app/models/job/state_machine.rb:52:in `signal'
	from /Users/nasarkhan/.rvm/gems/ruby-3.0.1/bundler/gems/manageiq-providers-ansible_tower-7d2a7bb7943d/app/models/manageiq/providers/ansible_tower/automation_manager/configuration_workflow.rb:9:in `run_with_miq_job'
```

Switching to a common parent class in `AutomationManager::ConfigurationScript` resolves the issue

@miq-bot add_label bug, radjabov/yes?
@miq-bot assign @agrare 
@miq-bot add_reviewer @jrafanie @agrare 