### PR TITLE
resource is an association, not an attribute, add getter/setter aliases

### DIFF
--- a/app/models/manageiq/providers/awx/automation_manager/credential.rb
+++ b/app/models/manageiq/providers/awx/automation_manager/credential.rb
@@ -4,7 +4,8 @@ class ManageIQ::Providers::Awx::AutomationManager::Credential < ManageIQ::Provid
   # CUD operations in the TowerApi concern
 
   alias_attribute :manager_id, :resource_id
-  alias_attribute :manager, :resource
+  alias_method :manager,  :resource
+  alias_method :manager=, :resource=
 
   include ManageIQ::Providers::Awx::AutomationManager::TowerApi
   include ProviderObjectMixin


### PR DESCRIPTION
Fixes:

```
ManageIQ::Providers::Awx::AutomationManager::Credential model aliases `resource`, but `resource` is not an attribute. Starting in Rails 7.2, alias_attribute with non-attribute targets will raise. Use `alias_method :manager, :resource` or define the method manually
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
