### PR TITLE
Parameterize resource display_name functions based on provider

### DIFF
--- a/app/models/manageiq/providers/awx/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/awx/automation_manager/configuration_script.rb
@@ -15,7 +15,7 @@ class ManageIQ::Providers::Awx::AutomationManager::ConfigurationScript <
   end
 
   def self.display_name(number = 1)
-    n_('Job Template (AWX)', 'Job Templates (AWX)', number)
+    n_('Job Template (%{provider_description})', 'Job Templates (%{provider_description})', number) % {:provider_description => module_parent.description}
   end
 
   def self.stack_type

--- a/app/models/manageiq/providers/awx/automation_manager/configuration_workflow.rb
+++ b/app/models/manageiq/providers/awx/automation_manager/configuration_workflow.rb
@@ -19,7 +19,7 @@ class ManageIQ::Providers::Awx::AutomationManager::ConfigurationWorkflow < Manag
   end
 
   def self.display_name(number = 1)
-    n_('Workflow Template (AWX)', 'Workflow Templates (AWX)', number)
+    n_('Workflow Template (%{provider_description})', 'Workflow Templates (%{provider_description})', number) % {:provider_description => module_parent.description}
   end
 
   def self.provider_collection(manager)

--- a/app/models/manageiq/providers/awx/automation_manager/configured_system.rb
+++ b/app/models/manageiq/providers/awx/automation_manager/configured_system.rb
@@ -3,7 +3,7 @@ class ManageIQ::Providers::Awx::AutomationManager::ConfiguredSystem <
   include ProviderObjectMixin
 
   def self.display_name(number = 1)
-    n_('Configured System (AWX)', 'Configured Systems (AWX)', number)
+    n_('Configured System (%{provider_description})', 'Configured Systems (%{provider_description})', number) % {:provider_description => module_parent.description}
   end
 
   def provider_object(connection = nil)

--- a/app/models/manageiq/providers/awx/automation_manager/job.rb
+++ b/app/models/manageiq/providers/awx/automation_manager/job.rb
@@ -8,7 +8,7 @@ class ManageIQ::Providers::Awx::AutomationManager::Job <
   virtual_has_many :job_plays
 
   def self.display_name(number = 1)
-    n_('AWX Job', 'AWX Jobs', number)
+    n_('%{provider_description} Job', '%{provider_description} Jobs', number) % {:provider_description => module_parent.description}
   end
 
   class << self

--- a/app/models/manageiq/providers/awx/automation_manager/playbook.rb
+++ b/app/models/manageiq/providers/awx/automation_manager/playbook.rb
@@ -4,6 +4,6 @@ class ManageIQ::Providers::Awx::AutomationManager::Playbook <
   has_many :jobs, :class_name => 'OrchestrationStack', :foreign_key => :configuration_script_base_id
 
   def self.display_name(number = 1)
-    n_('Playbook (AWX)', 'Playbooks (AWX)', number)
+    n_('Playbook (%{provider_description})', 'Playbooks (%{provider_description})', number) % {:provider_description => module_parent.description}
   end
 end

--- a/app/models/manageiq/providers/awx/automation_manager/workflow_job.rb
+++ b/app/models/manageiq/providers/awx/automation_manager/workflow_job.rb
@@ -37,7 +37,7 @@ class ManageIQ::Providers::Awx::AutomationManager::WorkflowJob <
   alias jobs orchestration_stacks
 
   def self.display_name(number = 1)
-    n_('AWX Workflow Job', 'AWX Workflow Jobs', number)
+    n_('%{provider_description} Workflow Job', '%{provider_description} Workflow Jobs', number) % {:provider_description => module_parent.description}
   end
 
   def raw_status


### PR DESCRIPTION
This will allow us to remove the display_name functions in the subclassed Ansible Tower provider

Needed for:
- [ ] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/319

@miq-bot assign @agrare 
@miq-bot add_label enhancement
@miq-bot add_reviewer @Fryguy, @agrare 