### PR TITLE
[WIP] Handle both `/api/controller/v2` and `/api/v2` API paths

### DIFF
--- a/app/models/manageiq/providers/awx/provider.rb
+++ b/app/models/manageiq/providers/awx/provider.rb
@@ -107,45 +107,54 @@ class ManageIQ::Providers::Awx::Provider < ::Provider
   # }
   def self.verify_credentials(args)
     default_authentication = args.dig("authentications", "default")
-    url = args.dig("endpoints", "default", "url")
+    default_endpoint       = args.dig("endpoints", "default")
+
+    url        = URI(default_endpoint["url"])
     verify_ssl = args.dig("endpoints", "default", "verify_ssl")
 
     userid   = default_authentication["userid"]
     password = ManageIQ::Password.try_decrypt(default_authentication["password"])
     password ||= find(args["id"]).authentication_password
 
-    verify_connection(raw_connect(url, userid, password, verify_ssl))
+    test_connection_with_api_paths(url, userid, password, verify_ssl)
   end
 
-  def self.default_api_path
-    "/api/v2".freeze
-  end
+  def self.test_connection_with_api_paths(url, userid, password, verify_ssl)
+    # If no API path is explicitly provided, attempt with the current and
+    # legacy automation controller API paths.
+    api_paths = url.path.present? ? [url.path] : ["/api/controller/v2", "/api/v2"]
 
-  def self.adjust_url(url)
-    URI(url).tap do |adjusted_url|
-      adjusted_url.path = default_api_path if adjusted_url.path.blank?
+    api_paths.each do |api_path|
+      connection_rescue_block do
+        test_url = url.dup.tap { |u| u.path = api_path }
+        verify_connection(raw_connect(test_url, userid, password, verify_ssl))
+      rescue AnsibleTowerClient::ResourceNotFoundError
+        # If a specific path was given by the user then we want to raise for a 404 error.
+        raise if url.path.present?
+      end
     end
+
+    true
   end
 
   def self.verify_connection(connection)
+    connection.api.verify_credentials
+  end
+
+  def self.connection_rescue_block
     require 'ansible_tower_client'
-    begin
-      connection.api.verify_credentials ||
-        raise(MiqException::MiqInvalidCredentialsError, _("Username or password is not valid"))
-    rescue AnsibleTowerClient::ClientError => err
-      raise MiqException::MiqCommunicationsError, err.message, err.backtrace
-    end
+    yield
+  rescue AnsibleTowerClient::ClientError => err
+    raise MiqException::MiqCommunicationsError, err.message, err.backtrace
   end
 
   def self.raw_connect(url, username, password, verify_ssl)
     raise ArgumentError, "Invalid URL" unless url_format_valid?(url)
 
-    base_url = adjust_url(url).to_s
-
     require 'ansible_tower_client'
     AnsibleTowerClient.logger = $ansible_tower_log
     AnsibleTowerClient::Connection.new(
-      :base_url   => base_url,
+      :base_url   => url,
       :username   => username,
       :password   => password,
       :verify_ssl => verify_ssl


### PR DESCRIPTION
We need to check both paths before failing verify_credentials at the class level, and store which path to use in the instance methods.

Fixes https://github.com/ManageIQ/manageiq-providers-ansible_tower/issues/335
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
