### PR TITLE
Attach Stack to Service when provisioning a Job Template

### DIFF
--- a/app/models/manageiq/providers/awx/automation_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/awx/automation_manager/provision/state_machine.rb
@@ -8,6 +8,8 @@ module ManageIQ::Providers::Awx::AutomationManager::Provision::StateMachine
     stack       = stack_class.create_stack(source)
 
     phase_context[:stack_id] = stack.id
+    connect_to_service!(stack)
+
     save!
 
     signal :check_provisioned
@@ -46,11 +48,19 @@ module ManageIQ::Providers::Awx::AutomationManager::Provision::StateMachine
     mark_execution_servers
   end
 
+  def connect_to_service!(stack)
+    service&.add_resource!(stack)
+  end
+
   def stack_klass
     @stack_klass ||= "#{source.class.module_parent}::#{source.class.stack_type}".constantize
   end
 
   def stack
     @stack ||= stack_klass.find(phase_context[:stack_id])
+  end
+
+  def service
+    @service ||= Service.find_by(:guid => options[:service_guid])
   end
 end

--- a/spec/models/manageiq/providers/awx/automation_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/awx/automation_manager/provision_spec.rb
@@ -58,6 +58,17 @@ describe ManageIQ::Providers::Awx::AutomationManager::Provision do
       expect(subject.reload.phase).to eq("check_provisioned")
     end
 
+    context "with a service_guid" do
+      let(:service) { FactoryBot.create(:service) }
+      let(:options)      { {:source => [job_template.id, job_template.name], :service_guid => service.guid} }
+
+      it "adds the stack to the service" do
+        subject.run_provision
+
+        expect(service.reload.service_resources.find_by(:resource_type => "OrchestrationStack").resource).to eq(new_stack)
+      end
+    end
+
     context "when create_stack fails" do
       before do
         expect(described_class.module_parent::Job).to receive(:create_stack).and_raise


### PR DESCRIPTION
If we are provisioning a Job Template for a Service Catalog order, add the created Orchestration Stack to the Service after it is created.

This was being done by the automate provision state machines but was missed when transitioning to the MiqProvisionTask style in https://github.com/ManageIQ/manageiq-providers-awx/pull/51
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
