### PR TITLE
[WIP] Drop the deprecated automate based provisioning

### DIFF
--- a/app/models/manageiq/providers/awx/automation_manager.rb
+++ b/app/models/manageiq/providers/awx/automation_manager.rb
@@ -56,7 +56,7 @@ class ManageIQ::Providers::Awx::AutomationManager < ManageIQ::Providers::Externa
   end
 
   def self.catalog_types
-    {"generic_awx" => N_("AWX (deprecated)"), "awx" => N_("AWX")}
+    {"awx" => N_("AWX")}
   end
 
   def self.display_name(number = 1)

--- a/spec/models/manageiq/providers/awx/automation_manager_spec.rb
+++ b/spec/models/manageiq/providers/awx/automation_manager_spec.rb
@@ -5,7 +5,7 @@ describe ManageIQ::Providers::Awx::AutomationManager do
     let(:ems) { FactoryBot.create(:automation_manager_awx) }
 
     it "#catalog_types" do
-      expect(ems.catalog_types).to eq({"awx" => "AWX", "generic_awx" => "AWX (deprecated)"})
+      expect(ems.catalog_types).to eq({"awx" => "AWX"})
     end
   end
 


### PR DESCRIPTION
We will have had the MiqProvision type of service catalog provisioning for 2 downstream releases and 1 upstream release so we can start to remove up the code supporting the old style.

Related:
* https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/341
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
