### PR TITLE
Replace Automation Manager strings with Automation Provider

### DIFF
--- a/app/models/manageiq/providers/awx/automation_manager.rb
+++ b/app/models/manageiq/providers/awx/automation_manager.rb
@@ -60,7 +60,7 @@ class ManageIQ::Providers::Awx::AutomationManager < ManageIQ::Providers::Externa
   end
 
   def self.display_name(number = 1)
-    n_('Automation Manager (AWX)', 'Automation Managers (AWX)', number)
+    n_('Automation Provider (AWX)', 'Automation Providers (AWX)', number)
   end
 
   def name


### PR DESCRIPTION
Replace Automation Manager strings with Automation Provider

Relevant PRs:
- https://github.com/ManageIQ/manageiq/pull/23915
- https://github.com/ManageIQ/manageiq-content/pull/793
- https://github.com/ManageIQ/manageiq-documentation/pull/1905
- https://github.com/ManageIQ/manageiq-ui-classic/pull/10162
- https://github.com/ManageIQ/manageiq-ui-service/pull/2110
- https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/344
- https://github.com/ManageIQ/manageiq-api-client/pull/165